### PR TITLE
Disable top-level Listen directive, collides with localized one

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -39,6 +39,8 @@ eval "cat > /usr/local/apache2/conf/proxy_ldap.conf << EOF
 $(cat /proxy_ldap.conf.template)
 EOF"
 
+sed -i -e 's/^Listen/# Listen/' /usr/local/apache2/conf/httpd.conf
+
 [[ -v DISPLAY_CONFIG ]] && {
   cat /usr/local/apache2/conf/proxy_ldap.conf
 }


### PR DESCRIPTION
The parent image has a 'Listen 80' in httpd.conf.  When proxy_ldap.conf also includes 'Listen 80' the result is an error 'could not bind to address'.  This change disables the Listen directive in httpd.conf in favor of proxy_ldap.conf